### PR TITLE
Bump version, add deprecation note for azure ext

### DIFF
--- a/ext/opentelemetry-ext-azure-monitor/CHANGELOG.md
+++ b/ext/opentelemetry-ext-azure-monitor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.2a1
+
+Released 2019-11-26
+
+- Add deprecation notice, redirect to opentelemetry-azure-monitor-exporter
+
 ## 0.2a0
 
 Released 2019-10-29

--- a/ext/opentelemetry-ext-azure-monitor/README.rst
+++ b/ext/opentelemetry-ext-azure-monitor/README.rst
@@ -1,17 +1,6 @@
 OpenTelemetry Azure Monitor Exporters
 =====================================
 
-This library provides integration with Microsoft Azure Monitor.
+Deprecated in favor of opentelemetry-ext-azure-monitor-exporter_.
 
-Installation
-------------
-
-::
-
-    pip install opentelemetry-ext-azure-monitor
-
-References
-----------
-
-* `Azure Monitor <https://docs.microsoft.com/azure/azure-monitor/>`_
-* `OpenTelemetry Project <https://opentelemetry.io/>`_
+.. _opentelemetry-ext-azure-monitor-exporter: https://pypi.org/project/opentelemetry-azure-monitor-exporter/

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/version.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.dev0"
+__version__ = "0.2a1"


### PR DESCRIPTION
This is an orphan branch of fb3e715, the last commit before the azure exporter was removed in https://github.com/open-telemetry/opentelemetry-python/pull/272.

I'll release `opentelemetry-ext-azure-monitor` version `0.2a1` from this branch.