### PR TITLE
use lock, removes needs to set runtime ctx

### DIFF
--- a/ext/opentelemetry-ext-grpc/tests/test_server_interceptor.py
+++ b/ext/opentelemetry-ext-grpc/tests/test_server_interceptor.py
@@ -21,8 +21,7 @@ from unittest.mock import patch
 
 import grpc
 
-from opentelemetry import context, trace
-from opentelemetry.context.threadlocal_context import ThreadLocalRuntimeContext
+from opentelemetry import trace
 from opentelemetry.ext.grpc import server_interceptor
 from opentelemetry.ext.grpc.grpcext import intercept_server
 from opentelemetry.sdk import trace as trace_sdk
@@ -53,14 +52,9 @@ class TestOpenTelemetryServerInterceptor(unittest.TestCase):
     # FIXME: test_concurrent_server_spans fails with contextvars context.
     def setUp(self) -> None:
         super(TestOpenTelemetryServerInterceptor, self).setUp()
-        self.mock_runtime = patch.object(
-            context, "_RUNTIME_CONTEXT", ThreadLocalRuntimeContext()
-        )
-        self.mock_runtime.start()
 
     def tearDown(self) -> None:
         super(TestOpenTelemetryServerInterceptor, self).tearDown()
-        self.mock_runtime.stop()
 
     def test_create_span(self):
         """Check that the interceptor wraps calls with spans server-side."""
@@ -192,11 +186,11 @@ class TestOpenTelemetryServerInterceptor(unittest.TestCase):
 
         # Capture the currently active span in each thread
         active_spans_in_handler = []
-        latch = get_latch(2)
+        lock = threading.Lock()
 
         def handler(request, context):
-            latch()
-            active_spans_in_handler.append(tracer.get_current_span())
+            with lock:
+                active_spans_in_handler.append(tracer.get_current_span())
             return b""
 
         server = grpc.server(
@@ -228,23 +222,3 @@ class TestOpenTelemetryServerInterceptor(unittest.TestCase):
         self.assertNotEqual(span1.context.trace_id, span2.context.trace_id)
         self.assertIsNone(span1.parent)
         self.assertIsNone(span1.parent)
-
-
-def get_latch(n):
-    """Get a countdown latch function for use in n threads."""
-    cv = threading.Condition()
-    count = 0
-
-    def countdown_latch():
-        """Block until n-1 other threads have called."""
-        nonlocal count
-        cv.acquire()
-        count += 1
-        cv.notify()
-        cv.release()
-        cv.acquire()
-        while count < n:
-            cv.wait()
-        cv.release()
-
-    return countdown_latch


### PR DESCRIPTION
Not sure if this is the cleanest solution here, but it does remove the need to use `ThreadLocalRuntimeContext` which is a plus.