### PR TITLE
need a lock when initializing the context

### DIFF
--- a/ext/opentelemetry-ext-grpc/tests/test_server_interceptor.py
+++ b/ext/opentelemetry-ext-grpc/tests/test_server_interceptor.py
@@ -17,12 +17,10 @@ import unittest
 from concurrent import futures
 from contextlib import contextmanager
 from unittest import mock
-from unittest.mock import patch
 
 import grpc
 
 from opentelemetry import context, trace
-from opentelemetry.context.threadlocal_context import ThreadLocalRuntimeContext
 from opentelemetry.ext.grpc import server_interceptor
 from opentelemetry.ext.grpc.grpcext import intercept_server
 from opentelemetry.sdk import trace as trace_sdk
@@ -49,19 +47,6 @@ class UnaryUnaryRpcHandler(grpc.GenericRpcHandler):
 
 
 class TestOpenTelemetryServerInterceptor(unittest.TestCase):
-
-    # FIXME: test_concurrent_server_spans fails with contextvars context.
-    def setUp(self) -> None:
-        super(TestOpenTelemetryServerInterceptor, self).setUp()
-        self.mock_runtime = patch.object(
-            context, "_RUNTIME_CONTEXT", ThreadLocalRuntimeContext()
-        )
-        self.mock_runtime.start()
-
-    def tearDown(self) -> None:
-        super(TestOpenTelemetryServerInterceptor, self).tearDown()
-        self.mock_runtime.stop()
-
     def test_create_span(self):
         """Check that the interceptor wraps calls with spans server-side."""
 

--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import threading
 import typing
 from functools import wraps
 from os import environ
@@ -24,7 +25,7 @@ from opentelemetry.context.context import Context, RuntimeContext
 
 logger = logging.getLogger(__name__)
 _RUNTIME_CONTEXT = None  # type: typing.Optional[RuntimeContext]
-
+_RUNTIME_CONTEXT_LOCK = threading.Lock()
 
 _F = typing.TypeVar("_F", bound=typing.Callable[..., typing.Any])
 
@@ -42,26 +43,30 @@ def _load_runtime_context(func: _F) -> _F:
         **kwargs: typing.Dict[typing.Any, typing.Any]
     ) -> typing.Optional[typing.Any]:
         global _RUNTIME_CONTEXT  # pylint: disable=global-statement
-        if _RUNTIME_CONTEXT is None:
-            # FIXME use a better implementation of a configuration manager to avoid having
-            # to get configuration values straight from environment variables
-            if version_info < (3, 5):
-                # contextvars are not supported in 3.4, use thread-local storage
-                default_context = "threadlocal_context"
-            else:
-                default_context = "contextvars_context"
 
-            configured_context = environ.get(
-                "OPENTELEMETRY_CONTEXT", default_context
-            )  # type: str
-            try:
-                _RUNTIME_CONTEXT = next(
-                    iter_entry_points(
-                        "opentelemetry_context", configured_context
+        with _RUNTIME_CONTEXT_LOCK:
+            if _RUNTIME_CONTEXT is None:
+                # FIXME use a better implementation of a configuration manager to avoid having
+                # to get configuration values straight from environment variables
+                if version_info < (3, 5):
+                    # contextvars are not supported in 3.4, use thread-local storage
+                    default_context = "threadlocal_context"
+                else:
+                    default_context = "contextvars_context"
+
+                configured_context = environ.get(
+                    "OPENTELEMETRY_CONTEXT", default_context
+                )  # type: str
+                try:
+                    _RUNTIME_CONTEXT = next(
+                        iter_entry_points(
+                            "opentelemetry_context", configured_context
+                        )
+                    ).load()()
+                except Exception:  # pylint: disable=broad-except
+                    logger.error(
+                        "Failed to load context: %s", configured_context
                     )
-                ).load()()
-            except Exception:  # pylint: disable=broad-except
-                logger.error("Failed to load context: %s", configured_context)
         return func(*args, **kwargs)  # type: ignore
 
     return wrapper  # type:ignore


### PR DESCRIPTION
Without this lock, multiple threads could be trying to set the global runtime context and that would be bad.

NOTE: there might be a more optimal amount of code to lock here.